### PR TITLE
Add column projection

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,12 @@ CREATE TABLE source_db.table_a
 ```
 
 ### Predicate Pushdown
-Pushdown of the HiveSQL `WHERE` clause has been implemented so that filters are pushed to the Iceberg `TableScan` level as well as the Parquet `Reader`. ORC implementations are still in the works. 
+Pushdown of the HiveSQL `WHERE` clause has been implemented so that filters are pushed to the Iceberg `TableScan` level as well as the Parquet `Reader`. ORC implementations are still in the works.
+**Note:** Predicate pushdown to the Iceberg table scan is only activated when using the `IcebergStorageHandler`. 
+
+
+### Column Projection
+The `IcebergInputFormat` will project columns from the HiveSQL `SELECT` section down to the Iceberg readers to reduce the amount of columns read. 
 
 # Legal
 This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Pushdown of the HiveSQL `WHERE` clause has been implemented so that filters are 
 
 
 ### Column Projection
-The `IcebergInputFormat` will project columns from the HiveSQL `SELECT` section down to the Iceberg readers to reduce the amount of columns read. 
+The `IcebergInputFormat` will project columns from the HiveSQL `SELECT` section down to the Iceberg readers to reduce the number of columns read. 
 
 # Legal
 This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).

--- a/src/main/java/com/expediagroup/hiveberg/IcebergInputFormat.java
+++ b/src/main/java/com/expediagroup/hiveberg/IcebergInputFormat.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hive.ql.io.CombineHiveInputFormat;
 import org.apache.hadoop.hive.ql.io.sarg.ConvertAstToSearchArg;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
 import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
+import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.InputSplit;
@@ -69,10 +70,12 @@ public class IcebergInputFormat implements InputFormat,  CombineHiveInputFormat.
     table = findTable(job);
     URI location = getPathURI(job.get(TABLE_LOCATION));
 
+    String[] readColumns = ColumnProjectionUtils.getReadColumnNames(job);
     List<CombinedScanTask> tasks;
     if(job.get(TABLE_FILTER_SERIALIZED) == null) {
       tasks = Lists.newArrayList(table
           .newScan()
+          .select(readColumns)
           .planTasks());
     } else {
       ExprNodeGenericFuncDesc exprNodeDesc = SerializationUtilities.
@@ -82,6 +85,7 @@ public class IcebergInputFormat implements InputFormat,  CombineHiveInputFormat.
 
       tasks = Lists.newArrayList(table
           .newScan()
+          .select(readColumns)
           .filter(filter)
           .planTasks());
     }


### PR DESCRIPTION
This PR is to address #5.

`ColumnProjectionUtils` is used to fetch the columns to read from the `JobConf`. This property is set within the `HiveInputFormat` before it calls the getSplits() method.