### PR TITLE
Time traveling!

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ CREATE TABLE source_db.table_a
   LOCATION 'path_to_iceberg_data_warehouse';
   TBLPROPERTIES('iceberg.catalog' = ...)
 ```
-Include the same `TBLPROPERTIES` as described in the 'Setting TBLPROPERTIES correctly` section, depending on how you've created your Iceberg table.
+Include the same `TBLPROPERTIES` as described in the 'Setting TBLPROPERTIES correctly' section, depending on how you've created your Iceberg table.
 
 ### Predicate Pushdown
 Pushdown of the HiveSQL `WHERE` clause has been implemented so that filters are pushed to the Iceberg `TableScan` level as well as the Parquet `Reader`. ORC implementations are still in the works.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Time travel is only available when using the `IcebergStorageHandler`.
 Specific snapshots can be selected from your Iceberg table using a provided virtual column that exposes the snapshot id. The default name for this column is `snapshot__id`. However, if you wish to change the name of the snapshot column, you can modify the name by setting a table property like so: 
 
 ```sql
-TBLPROPERTIES ('hiveberg.snapshot.virtual.column.name' = 'new_column_name')
+TBLPROPERTIES ('iceberg.hive.snapshot.virtual.column.name' = 'new_column_name')
 ```
 
 To achieve time travel, and query an older snapshot, you can execute a Hive query similar to: 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,12 @@ committed_at | snapshot_id | parent_id | operation | manifest_list | summary
 
 Time travel is available when using the `IcebergStorageHandler`. 
 
-Execute a Hive query similar to: 
+The default column name to query for time travel is `snapshot__id`. If your table schema has a column with the same name as this, you can configure Hiveberg to use a different column name for the virtual column using: 
+
+`'hiveberg.snapshot.virtual.column.name' = 'new_column_name'`
+
+
+To query an older snapshot, execute a Hive query similar to: 
 ```sql
 SELECT * FROM table_a WHERE snapshot__id = 1234567890 
 ```

--- a/README.md
+++ b/README.md
@@ -22,24 +22,26 @@ CREATE TABLE source_db.table_a
   STORED AS
     INPUTFORMAT 'com.expediagroup.hiveberg.IcebergInputFormat'
     OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
-  LOCATION 'path_to_iceberg_table_location';
+  LOCATION 'path_to_iceberg_table_location'
+  TBLPROPERTIES('iceberg.catalog' = ...);
 ```
-
-**NOTE:** You need to set extra `TBLPROPERTIES` depending on how you've created your Iceberg table.
-- **HadoopTables**: Add one extra configurations: 
-```sql 
-    TBLPROPERTIES('iceberg.catalog' = 'hadoop.tables')
-```
-- **HadoopCatalog**: Add these extra configurations: 
-```sql 
-    TBLPROPERTIES('iceberg.catalog' = 'hadoop.catalog', 'iceberg.warehouse.location' = 'path_to_warehouse_location')
-```
-
-You must ensure that your Hive table has the **same** name as your Iceberg table. 
+You must ensure that your Hive table has the **same** name as your Iceberg table. The `InputFormat` uses the `name` property from the Hive table to load the correct Iceberg table for the read.
 For example, if you created the Hive table as shown above then your Iceberg table must be created using a `TableIdentifier` as follows where both table names match: 
 ```
 TableIdentifier id = TableIdentifier.parse("source_db.table_a");
 ```
+
+#### Setting TBLPROPERTIES correctly
+You need to set the `TBLPROPERTIES` differently depending on how you've created your Iceberg table.
+- If you used **HadoopTables** to create your Iceberg table, add one extra configuration: 
+```sql 
+    TBLPROPERTIES('iceberg.catalog' = 'hadoop.tables')
+```
+- If you used **HadoopCatalog** to create your Iceberg table, add these extra configurations: 
+```sql 
+    TBLPROPERTIES('iceberg.catalog' = 'hadoop.catalog', 'iceberg.warehouse.location' = 'path_to_warehouse_location')
+```
+These properties need to be set so the `InputFormat` can load the Iceberg table using the correct class.
 
 ### IcebergStorageHandler
 This is implemented as a simplified option for creating Hiveberg tables. The Hive DDL should instead look like:
@@ -49,7 +51,7 @@ CREATE TABLE source_db.table_a
   LOCATION 'path_to_iceberg_data_warehouse';
   TBLPROPERTIES('iceberg.catalog' = ...)
 ```
-Include the same `TBLPROPERTIES` as described above depending on how you've created your Iceberg table.
+Include the same `TBLPROPERTIES` as described in the 'Setting TBLPROPERTIES correctly` section, depending on how you've created your Iceberg table.
 
 ### Predicate Pushdown
 Pushdown of the HiveSQL `WHERE` clause has been implemented so that filters are pushed to the Iceberg `TableScan` level as well as the Parquet `Reader`. ORC implementations are still in the works.
@@ -62,7 +64,7 @@ The `IcebergInputFormat` will project columns from the HiveSQL `SELECT` section 
 ### Time Travel and System Tables
 You can view snapshot metadata from your table by creating a `__snapshots` system table linked to your data table. To do this: 
 1. Create your regular table as outlined above.
-1. Create another where the Hive DDL looks similar to: 
+1. Create another table where the Hive DDL looks similar to: 
 ```sql
 CREATE TABLE source_db.table_a__snapshots
   STORED BY 'com.expediagroup.hiveberg.IcebergStorageHandler'
@@ -70,24 +72,25 @@ CREATE TABLE source_db.table_a__snapshots
     TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog', 'iceberg.warehouse.location'='path_to_original_table_warehouse')
 ```
 Notes: 
-- It is important that the table name ends with `__snapshots` as that is how the InputFormat determines when to load the snapshot metadata. 
-- If you want to create a regular data table with a name that ends in `__snapshots` but do NOT want to load the snapshots table, you can set the `iceberg.snapshots.table` property to `false` under `TBLPROPERTIES`.
+- It is important that the table name ends with `__snapshots` as the `InputFormat` uses this to determine when to load the snapshot metadata table instead of the regular data table. 
+- If you want to create a regular data table with a name that ends in `__snapshots` but do **not** want to load the snapshots table, you can override this default behaviour by setting the `iceberg.snapshots.table=false` in the `TBLPROPERTIES`.
 
-Running a `SELECT * FROM table_a__snapshots` query will get you results similar to: 
+Running a `SELECT * FROM table_a__snapshots` query will return you the table snapshot metadata with results similar to the following: 
 
 committed_at | snapshot_id | parent_id | operation | manifest_list | summary 
 --- | --- | --- | --- | --- | --- |
 1588341995546 | 6023596325564622918 | null | append | /var/folders/sg/... | {"added-data-files":"1","added-records":"3","changed-partition-count":"1","total-records":"3","total-data-files":"1"} 
 1588857355026 | 544685312650116825 | 6023596325564622918 | append | /var/folders/sg/... | {"added-data-files":"1","added-records":"3","changed-partition-count":"1","total-records":"6","total-data-files":"2"} 
 
-Time travel is available when using the `IcebergStorageHandler`. 
+Time travel is only available when using the `IcebergStorageHandler`. 
 
-The default column name to query for time travel is `snapshot__id`. If your table schema has a column with the same name as this, you can configure Hiveberg to use a different column name for the virtual column using: 
+Specific snapshots can be selected from your Iceberg table using a provided virtual column that exposes the snapshot id. The default name for this column is `snapshot__id`. However, if you wish to change the name of the snapshot column, you can modify the name by setting a table property like so: 
 
-`'hiveberg.snapshot.virtual.column.name' = 'new_column_name'`
+```sql
+TBLPROPERTIES ('hiveberg.snapshot.virtual.column.name' = 'new_column_name')
+```
 
-
-To query an older snapshot, execute a Hive query similar to: 
+To achieve time travel, and query an older snapshot, you can execute a Hive query similar to: 
 ```sql
 SELECT * FROM table_a WHERE snapshot__id = 1234567890 
 ```

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ CREATE TABLE source_db.table_a__snapshots
   LOCATION 'path_to_original_data_table'
     TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog', 'iceberg.warehouse.location'='path_to_original_table_warehouse')
 ```
-Notes: 
+#### Notes
 - It is important that the table name ends with `__snapshots` as the `InputFormat` uses this to determine when to load the snapshot metadata table instead of the regular data table. 
 - If you want to create a regular data table with a name that ends in `__snapshots` but do **not** want to load the snapshots table, you can override this default behaviour by setting the `iceberg.snapshots.table=false` in the `TBLPROPERTIES`.
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,20 @@ CREATE TABLE source_db.table_a
   STORED AS
     INPUTFORMAT 'com.expediagroup.hiveberg.IcebergInputFormat'
     OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
-  LOCATION 'path_to_iceberg_data_warehouse';
+  LOCATION 'path_to_iceberg_table_location';
 ```
 
-You must ensure that:
-- You are creating Iceberg tables using the Iceberg `HadoopCatalog` API. 
-    - Using this means all your Iceberg tables are created under one common location which you must point the Hive table `LOCATION` at. 
-- Ensure your Hive table has the **same** name as your Iceberg table. 
+**NOTE:** You need to set extra `TBLPROPERTIES` depending on how you've created your Iceberg table.
+- **HadoopTables**: Add one extra configurations: 
+```sql 
+    TBLPROPERTIES('iceberg.catalog' = 'hadoop.tables')
+```
+- **HadoopCatalog**: Add these extra configurations: 
+```sql 
+    TBLPROPERTIES('iceberg.catalog' = 'hadoop.catalog', 'iceberg.warehouse.location' = 'path_to_warehouse_location')
+```
 
+You must ensure that your Hive table has the **same** name as your Iceberg table. 
 For example, if you created the Hive table as shown above then your Iceberg table must be created using a `TableIdentifier` as follows where both table names match: 
 ```
 TableIdentifier id = TableIdentifier.parse("source_db.table_a");
@@ -41,7 +47,9 @@ This is implemented as a simplified option for creating Hiveberg tables. The Hiv
 CREATE TABLE source_db.table_a
   STORED BY 'com.expediagroup.hiveberg.IcebergStorageHandler'
   LOCATION 'path_to_iceberg_data_warehouse';
+  TBLPROPERTIES('iceberg.catalog' = ...)
 ```
+Include the same `TBLPROPERTIES` as described above depending on how you've created your Iceberg table.
 
 ### Predicate Pushdown
 Pushdown of the HiveSQL `WHERE` clause has been implemented so that filters are pushed to the Iceberg `TableScan` level as well as the Parquet `Reader`. ORC implementations are still in the works.
@@ -50,6 +58,34 @@ Pushdown of the HiveSQL `WHERE` clause has been implemented so that filters are 
 
 ### Column Projection
 The `IcebergInputFormat` will project columns from the HiveSQL `SELECT` section down to the Iceberg readers to reduce the number of columns read. 
+
+### Time Travel and System Tables
+You can view snapshot metadata from your table by creating a `__snapshots` system table linked to your data table. To do this: 
+1. Create your regular table as outlined above.
+1. Create another where the Hive DDL looks similar to: 
+```sql
+CREATE TABLE source_db.table_a__snapshots
+  STORED BY 'com.expediagroup.hiveberg.IcebergStorageHandler'
+  LOCATION 'path_to_original_data_table'
+    TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog', 'iceberg.warehouse.location'='path_to_original_table_warehouse')
+```
+Notes: 
+- It is important that the table name ends with `__snapshots` as that is how the InputFormat determines when to load the snapshot metadata. 
+- If you want to create a regular data table with a name that ends in `__snapshots` but do NOT want to load the snapshots table, you can set the `iceberg.snapshots.table` property to `false` under `TBLPROPERTIES`.
+
+Running a `SELECT * FROM table_a__snapshots` query will get you results similar to: 
+
+committed_at | snapshot_id | parent_id | operation | manifest_list | summary 
+--- | --- | --- | --- | --- | --- |
+1588341995546 | 6023596325564622918 | null | append | /var/folders/sg/... | {"added-data-files":"1","added-records":"3","changed-partition-count":"1","total-records":"3","total-data-files":"1"} 
+1588857355026 | 544685312650116825 | 6023596325564622918 | append | /var/folders/sg/... | {"added-data-files":"1","added-records":"3","changed-partition-count":"1","total-records":"6","total-data-files":"2"} 
+
+Time travel is available when using the `IcebergStorageHandler`. 
+
+Execute a Hive query similar to: 
+```sql
+SELECT * FROM table_a WHERE snapshot__id = 1234567890 
+```
 
 # Legal
 This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <!-- this requires https://github.com/ExpediaGroup/incubator-iceberg/tree/build-hiveberg-modules to be built and installed
       locally -->
-    <iceberg.version>0.7.1-incubating</iceberg.version>
+    <iceberg.version>0.7.2-incubating</iceberg.version>
     <hive.version>2.3.6</hive.version>
   </properties>
 
@@ -69,6 +69,12 @@
     <dependency>
       <groupId>org.apache.iceberg</groupId>
       <artifactId>iceberg-parquet</artifactId>
+      <version>${iceberg.version}</version>
+      <classifier>all</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.iceberg</groupId>
+      <artifactId>iceberg-orc</artifactId>
       <version>${iceberg.version}</version>
       <classifier>all</classifier>
     </dependency>

--- a/src/main/java/com/expediagroup/hiveberg/IcebergFilterFactory.java
+++ b/src/main/java/com/expediagroup/hiveberg/IcebergFilterFactory.java
@@ -131,7 +131,7 @@ public class IcebergFilterFactory {
    */
   private static Expression translateLeaf(PredicateLeaf leaf) {
     String column = leaf.getColumnName();
-    if(column.equals("snapshot_id")) {
+    if(column.equals("snapshot__id")) {
       return Expressions.alwaysTrue();
     }
     switch (leaf.getOperator()){

--- a/src/main/java/com/expediagroup/hiveberg/IcebergFilterFactory.java
+++ b/src/main/java/com/expediagroup/hiveberg/IcebergFilterFactory.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hive.ql.io.sarg.ExpressionTree;
 import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
 import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
 
 import static org.apache.iceberg.expressions.Expressions.and;
 import static org.apache.iceberg.expressions.Expressions.equal;
@@ -130,6 +131,9 @@ public class IcebergFilterFactory {
    */
   private static Expression translateLeaf(PredicateLeaf leaf) {
     String column = leaf.getColumnName();
+    if(column.equals("snapshot_id")) {
+      return Expressions.alwaysTrue();
+    }
     switch (leaf.getOperator()){
       case EQUALS:
         return equal(column, leaf.getLiteral());

--- a/src/main/java/com/expediagroup/hiveberg/IcebergInputFormat.java
+++ b/src/main/java/com/expediagroup/hiveberg/IcebergInputFormat.java
@@ -44,7 +44,6 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.hadoop.HadoopInputFile;
-import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.InputFile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -115,7 +114,7 @@ public class IcebergInputFormat implements InputFormat,  CombineHiveInputFormat.
     private IcebergSplit split;
 
     private Iterator<FileScanTask> tasks;
-    private CloseableIterable<Record> reader;
+    private Iterable<Record> reader;
     private Iterator<Record> recordIterator;
     private Record currentRecord;
 
@@ -138,7 +137,7 @@ public class IcebergInputFormat implements InputFormat,  CombineHiveInputFormat.
       boolean reuseContainers = true; // FIXME: read from config
 
       IcebergReaderFactory readerFactory = new IcebergReaderFactory();
-      reader = readerFactory.createReader(file, currentTask, inputFile, tableSchema, reuseContainers);
+      reader = readerFactory.createReader(file, currentTask, inputFile, tableSchema, reuseContainers, table);
       recordIterator = reader.iterator();
     }
 

--- a/src/main/java/com/expediagroup/hiveberg/IcebergInputFormat.java
+++ b/src/main/java/com/expediagroup/hiveberg/IcebergInputFormat.java
@@ -76,7 +76,7 @@ public class IcebergInputFormat implements InputFormat,  CombineHiveInputFormat.
     table = resolveTableFromJob(job);
     URI location = pathAsURI(job.get(TABLE_LOCATION));
 
-    //Set defaults for virtual column
+    // Set defaults for virtual column
     currentSnapshotId = table.currentSnapshot().snapshotId();
     virtualSnapshotIdColumnName = getVirtualColumnName(job);
 

--- a/src/main/java/com/expediagroup/hiveberg/IcebergReaderFactory.java
+++ b/src/main/java/com/expediagroup/hiveberg/IcebergReaderFactory.java
@@ -68,7 +68,7 @@ class IcebergReaderFactory {
   private CloseableIterable buildOrcReader(FileScanTask task, InputFile file, Schema schema, boolean reuseContainers) {
     ORC.ReadBuilder builder = ORC.read(file)
 //            .createReaderFunc() // FIXME: implement
-        .schema(schema)
+        .project(schema)
         .split(task.start(), task.length());
 
     return builder.build();

--- a/src/main/java/com/expediagroup/hiveberg/IcebergSchemaToTypeInfo.java
+++ b/src/main/java/com/expediagroup/hiveberg/IcebergSchemaToTypeInfo.java
@@ -45,7 +45,9 @@ final class IcebergSchemaToTypeInfo {
       .put(Types.BinaryType.get(), TypeInfoFactory.getPrimitiveTypeInfo(serdeConstants.BINARY_TYPE_NAME))
       .put(Types.StringType.get(), TypeInfoFactory.getPrimitiveTypeInfo(serdeConstants.STRING_TYPE_NAME))
       .put(Types.DateType.get(), TypeInfoFactory.getPrimitiveTypeInfo(serdeConstants.DATE_TYPE_NAME))
-      .put(Types.TimestampType.withoutZone(), TypeInfoFactory.getPrimitiveTypeInfo(serdeConstants.TIMESTAMP_TYPE_NAME)).build();
+      .put(Types.TimestampType.withoutZone(), TypeInfoFactory.getPrimitiveTypeInfo(serdeConstants.BIGINT_TYPE_NAME))
+      .put(Types.TimestampType.withZone(), TypeInfoFactory.getPrimitiveTypeInfo(serdeConstants.BIGINT_TYPE_NAME))
+      .build();
 
   public static List<TypeInfo> getColumnTypes(Schema schema) throws Exception {
     List<Types.NestedField> fields = schema.columns();

--- a/src/main/java/com/expediagroup/hiveberg/IcebergSerDe.java
+++ b/src/main/java/com/expediagroup/hiveberg/IcebergSerDe.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.SnapshotsTable;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.types.Types;
 
+import static com.expediagroup.hiveberg.SystemTableUtil.getVirtualColumnName;
 import static com.expediagroup.hiveberg.TableResolverUtil.resolveTableFromConfiguration;
 
 public class IcebergSerDe extends AbstractSerDe {
@@ -57,7 +58,7 @@ public class IcebergSerDe extends AbstractSerDe {
       }
     } else {
       List<Types.NestedField> columns = new ArrayList<>(schema.columns());
-      columns.add(Types.NestedField.optional(9999, "snapshot_id", Types.LongType.get()));
+      columns.add(Types.NestedField.optional(Integer.MAX_VALUE, getVirtualColumnName(serDeProperties), Types.LongType.get()));
       Schema withVirtualColumn = new Schema(columns);
 
       try {

--- a/src/main/java/com/expediagroup/hiveberg/IcebergSerDe.java
+++ b/src/main/java/com/expediagroup/hiveberg/IcebergSerDe.java
@@ -48,7 +48,6 @@ public class IcebergSerDe extends AbstractSerDe {
       throw new UncheckedIOException("Unable to resolve table from configuration: ", e);
     }
     this.schema = table.schema();
-
     try {
       this.inspector = new IcebergObjectInspectorGenerator().createObjectInspector(schema);
     } catch (Exception e) {

--- a/src/main/java/com/expediagroup/hiveberg/IcebergStorageHandler.java
+++ b/src/main/java/com/expediagroup/hiveberg/IcebergStorageHandler.java
@@ -15,22 +15,30 @@
  */
 package com.expediagroup.hiveberg;
 
+import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.HiveMetaHook;
 import org.apache.hadoop.hive.ql.exec.SerializationUtilities;
 import org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat;
+import org.apache.hadoop.hive.ql.io.sarg.ConvertAstToSearchArg;
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
 import org.apache.hadoop.hive.ql.metadata.DefaultStorageHandler;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.metadata.HiveStorageHandler;
 import org.apache.hadoop.hive.ql.metadata.HiveStoragePredicateHandler;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
 import org.apache.hadoop.hive.ql.plan.TableDesc;
+import org.apache.hadoop.hive.ql.security.authorization.HiveAuthorizationProvider;
 import org.apache.hadoop.hive.serde2.AbstractSerDe;
 import org.apache.hadoop.hive.serde2.Deserializer;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.OutputFormat;
 
-public class IcebergStorageHandler extends DefaultStorageHandler implements HiveStoragePredicateHandler {
+public class IcebergStorageHandler implements HiveStoragePredicateHandler, HiveStorageHandler {
 
   private Configuration conf;
 
@@ -50,23 +58,33 @@ public class IcebergStorageHandler extends DefaultStorageHandler implements Hive
   }
 
   @Override
-  public void configureInputJobProperties(TableDesc tableDesc, Map<String, String> jobProperties) {
-    super.configureInputJobProperties(tableDesc, jobProperties);
+  public HiveMetaHook getMetaHook() {
+    return null;
   }
 
   @Override
-  public void configureOutputJobProperties(TableDesc tableDesc, Map<String, String> jobProperties) {
-    super.configureOutputJobProperties(tableDesc, jobProperties);
+  public HiveAuthorizationProvider getAuthorizationProvider() throws HiveException {
+    return null;
   }
 
   @Override
-  public void configureTableJobProperties(TableDesc tableDesc, Map<String, String> jobProperties) {
-    super.configureTableJobProperties(tableDesc, jobProperties);
+  public void configureInputJobProperties(TableDesc tableDesc, Map<String, String> map) {
+
+  }
+
+  @Override
+  public void configureOutputJobProperties(TableDesc tableDesc, Map<String, String> map) {
+
+  }
+
+  @Override
+  public void configureTableJobProperties(TableDesc tableDesc, Map<String, String> map) {
+
   }
 
   @Override
   public void configureJobConf(TableDesc tableDesc, JobConf jobConf) {
-    super.configureJobConf(tableDesc, jobConf);
+
   }
 
   @Override
@@ -93,11 +111,10 @@ public class IcebergStorageHandler extends DefaultStorageHandler implements Hive
    */
   @Override
   public DecomposedPredicate decomposePredicate(JobConf jobConf, Deserializer deserializer, ExprNodeDesc exprNodeDesc) {
-    getConf().set("iceberg.filter.serialized", SerializationUtilities.serializeObject(exprNodeDesc));
-
     //TODO: Decide what Iceberg can handle and what to return to Hive
     DecomposedPredicate predicate = new DecomposedPredicate();
     predicate.residualPredicate = (ExprNodeGenericFuncDesc) exprNodeDesc;
+    predicate.pushedPredicate = (ExprNodeGenericFuncDesc) exprNodeDesc;
     return predicate;
   }
 }

--- a/src/main/java/com/expediagroup/hiveberg/IcebergStorageHandler.java
+++ b/src/main/java/com/expediagroup/hiveberg/IcebergStorageHandler.java
@@ -15,16 +15,10 @@
  */
 package com.expediagroup.hiveberg;
 
-import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.HiveMetaHook;
-import org.apache.hadoop.hive.ql.exec.SerializationUtilities;
 import org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat;
-import org.apache.hadoop.hive.ql.io.sarg.ConvertAstToSearchArg;
-import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
-import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
-import org.apache.hadoop.hive.ql.metadata.DefaultStorageHandler;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.metadata.HiveStorageHandler;
 import org.apache.hadoop.hive.ql.metadata.HiveStoragePredicateHandler;

--- a/src/main/java/com/expediagroup/hiveberg/SystemTableUtil.java
+++ b/src/main/java/com/expediagroup/hiveberg/SystemTableUtil.java
@@ -26,7 +26,7 @@ import org.apache.iceberg.types.Types;
 
 public class SystemTableUtil {
 
-  static final String VIRTUAL_COLUMN_NAME = "hiveberg.snapshot.virtual.column.name";
+  static final String VIRTUAL_COLUMN_NAME = "iceberg.hive.snapshot.virtual.column.name";
 
   private static final String DEFAULT_SNAPSHOT_ID_COLUMN_NAME = "snapshot__id";
 

--- a/src/main/java/com/expediagroup/hiveberg/SystemTableUtil.java
+++ b/src/main/java/com/expediagroup/hiveberg/SystemTableUtil.java
@@ -28,7 +28,7 @@ public class SystemTableUtil {
 
   static final String VIRTUAL_COLUMN_NAME = "hiveberg.snapshot.virtual.column.name";
 
-  private static String defaultSnapshotIdColumnName = "snapshot__id";
+  private static final String DEFAULT_SNAPSHOT_ID_COLUMN_NAME = "snapshot__id";
 
   private SystemTableUtil() {}
 
@@ -51,7 +51,7 @@ public class SystemTableUtil {
   protected static String getVirtualColumnName(Configuration conf) {
     String virtualColumnName = conf.get(VIRTUAL_COLUMN_NAME);
     if(virtualColumnName == null) {
-      return defaultSnapshotIdColumnName;
+      return DEFAULT_SNAPSHOT_ID_COLUMN_NAME;
     } else {
       return virtualColumnName;
     }
@@ -60,7 +60,7 @@ public class SystemTableUtil {
   protected static String getVirtualColumnName(Properties properties) {
     String virtualColumnName = properties.getProperty(VIRTUAL_COLUMN_NAME);
     if(virtualColumnName == null) {
-      return defaultSnapshotIdColumnName;
+      return DEFAULT_SNAPSHOT_ID_COLUMN_NAME;
     } else {
       return virtualColumnName;
     }

--- a/src/main/java/com/expediagroup/hiveberg/SystemTableUtil.java
+++ b/src/main/java/com/expediagroup/hiveberg/SystemTableUtil.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2020 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.hiveberg;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.types.Types;
+
+public class SystemTableUtil {
+
+  static final String VIRTUAL_COLUMN_NAME = "hiveberg.snapshot.virtual.column.name";
+
+  private static String defaultSnapshotIdColumnName = "snapshot__id";
+
+  private SystemTableUtil() {}
+
+  protected static Schema schemaWithVirtualColumn(Schema schema, String columnName) {
+    List<Types.NestedField> columns = new ArrayList<>(schema.columns());
+    columns.add(Types.NestedField.optional(Integer.MAX_VALUE, columnName, Types.LongType.get()));
+    return new Schema(columns);
+  }
+
+  protected static Record recordWithVirtualColumn (Record record, long snapshotId, Schema oldSchema, String columnName) {
+    Schema newSchema = schemaWithVirtualColumn(oldSchema, columnName);
+    Record newRecord = GenericRecord.create(newSchema);
+    for(Types.NestedField field: oldSchema.columns()) {
+      newRecord.setField(field.name(), record.getField(field.name()));
+    }
+    newRecord.setField(columnName, snapshotId);
+    return newRecord;
+  }
+
+  protected static String getVirtualColumnName(Configuration conf) {
+    String virtualColumnName = conf.get(VIRTUAL_COLUMN_NAME);
+    if(virtualColumnName == null) {
+      return defaultSnapshotIdColumnName;
+    } else {
+      return virtualColumnName;
+    }
+  }
+
+  protected static String getVirtualColumnName(Properties properties) {
+    String virtualColumnName = properties.getProperty(VIRTUAL_COLUMN_NAME);
+    if(virtualColumnName == null) {
+      return defaultSnapshotIdColumnName;
+    } else {
+      return virtualColumnName;
+    }
+  }
+
+}

--- a/src/main/java/com/expediagroup/hiveberg/TableResolverUtil.java
+++ b/src/main/java/com/expediagroup/hiveberg/TableResolverUtil.java
@@ -43,7 +43,7 @@ final class TableResolverUtil {
 
   static Table resolveTableFromJob(JobConf conf) throws IOException {
     Properties properties = new Properties();
-      properties.setProperty(CATALOG_NAME, extractProperty(conf, CATALOG_NAME));
+    properties.setProperty(CATALOG_NAME, extractProperty(conf, CATALOG_NAME));
     if(conf.get(CATALOG_NAME).equals(HADOOP_CATALOG)) {
       properties.setProperty(WAREHOUSE_LOCATION, extractProperty(conf, WAREHOUSE_LOCATION));
       properties.setProperty(SNAPSHOT_TABLE, conf.get(SNAPSHOT_TABLE, "true"));

--- a/src/main/java/com/expediagroup/hiveberg/iterables/SnapshotIterable.java
+++ b/src/main/java/com/expediagroup/hiveberg/iterables/SnapshotIterable.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2020 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.hiveberg.iterables;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+
+/**
+ * To create an iterator of Records for snapshot metadata rows that Hive can read.
+ */
+public class SnapshotIterable implements Iterable  {
+
+  private Table table;
+
+  public SnapshotIterable(Table table) {
+    this.table = table;
+  }
+
+  public Iterator<Record> iterator() {
+    Iterable<Snapshot> snapshots = table.snapshots();
+    List<Record> snapRecords = new ArrayList<>();
+    snapshots.forEach(snapshot -> snapRecords.add(createSnapshotRecord(snapshot)));
+
+    return snapRecords.iterator();
+  }
+
+  /**
+   * Populating a Record with snapshot metadata
+   */
+  private Record createSnapshotRecord(Snapshot snapshot) {
+    Record snapRecord = GenericRecord.create(table.schema());
+    snapRecord.setField("committed_at", snapshot.timestampMillis());
+    snapRecord.setField("snapshot_id", snapshot.snapshotId());
+    snapRecord.setField("parent_id", snapshot.parentId());
+    snapRecord.setField("operation", snapshot.operation());
+    snapRecord.setField("manifest_list", snapshot.manifestListLocation());
+    snapRecord.setField("summary", snapshot.summary());
+    return snapRecord;
+  }
+}

--- a/src/test/java/com/expediagroup/hiveberg/TestInputFormatWithHadoopCatalog.java
+++ b/src/test/java/com/expediagroup/hiveberg/TestInputFormatWithHadoopCatalog.java
@@ -97,7 +97,7 @@ public class TestInputFormatWithHadoopCatalog {
         .append("')")
         .toString());
 
-    List<Object[]> result = shell.executeStatement("SELECT * FROM source_db.table_a");
+    List<Object[]> result = shell.executeStatement("SELECT id, data FROM source_db.table_a");
 
     assertEquals(3, result.size());
     assertArrayEquals(new Object[]{1L, "Michael"}, result.get(0));
@@ -121,7 +121,7 @@ public class TestInputFormatWithHadoopCatalog {
         .append("')")
         .toString());
 
-    List<Object[]> result = shell.executeStatement("SELECT * FROM source_db.table_a");
+    List<Object[]> result = shell.executeStatement("SELECT id, data FROM source_db.table_a");
 
     assertEquals(3, result.size());
     assertArrayEquals(new Object[]{1L, "Michael"}, result.get(0));

--- a/src/test/java/com/expediagroup/hiveberg/TestInputFormatWithHadoopTables.java
+++ b/src/test/java/com/expediagroup/hiveberg/TestInputFormatWithHadoopTables.java
@@ -92,7 +92,7 @@ public class TestInputFormatWithHadoopTables {
         .append(")")
         .toString());
 
-    List<Object[]> result = shell.executeStatement("SELECT * FROM source_db.table_a");
+    List<Object[]> result = shell.executeStatement("SELECT id, data FROM source_db.table_a");
 
     assertEquals(3, result.size());
     assertArrayEquals(new Object[]{1L, "Michael"}, result.get(0));

--- a/src/test/java/com/expediagroup/hiveberg/TestReadSnapshotTable.java
+++ b/src/test/java/com/expediagroup/hiveberg/TestReadSnapshotTable.java
@@ -174,25 +174,4 @@ public class TestReadSnapshotTable {
     List<Object[]> resultLatestSnapshotAgain = shell.executeStatement("SELECT * FROM source_db.table_a");
     assertEquals(9, resultLatestSnapshotAgain.size());
   }
-
-  @Test
-  public void testSnapshotFunc() throws IOException {
-    TableIdentifier id = TableIdentifier.parse("source_db.table_a__snapshots");
-    Table table = catalog.createTable(id, schema, PartitionSpec.unpartitioned());
-
-    List<Record> data = new ArrayList<>();
-    data.add(TestHelpers.createSimpleRecord(1L, "Michael"));
-    DataFile fileA = TestHelpers.writeFile(temp.newFile(), table, null, FileFormat.PARQUET, data);
-    table.newAppend().appendFile(fileA).commit();
-    table.newAppend().appendFile(fileA).commit();
-    table.newAppend().appendFile(fileA).commit();
-
-    long mostRecentId = table.currentSnapshot().snapshotId();
-    List<Snapshot> snapshots = Lists.newArrayList(table.snapshots());
-    long oldestId = snapshots.get(0).snapshotId();
-
-    table.manageSnapshots().rollbackTo(oldestId).commit();
-    table.refresh();
-  }
-
 }

--- a/src/test/java/com/expediagroup/hiveberg/TestReadSnapshotTable.java
+++ b/src/test/java/com/expediagroup/hiveberg/TestReadSnapshotTable.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (C) 2020 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.hiveberg;
+
+import com.klarna.hiverunner.HiveShell;
+import com.klarna.hiverunner.StandaloneHiveRunner;
+import com.klarna.hiverunner.annotations.HiveSQL;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.apache.iceberg.types.Types;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(StandaloneHiveRunner.class)
+public class TestReadSnapshotTable {
+
+  @HiveSQL(files = {}, autoStart = true)
+  private HiveShell shell;
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  private File tableLocation;
+
+  @Before
+  public void before() throws IOException {
+    tableLocation = temp.newFolder();
+    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
+        optional(2, "data", Types.StringType.get()));
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+
+    Configuration conf = new Configuration();
+    HadoopCatalog catalog = new HadoopCatalog(conf, tableLocation.getAbsolutePath());
+    TableIdentifier id = TableIdentifier.parse("source_db.table_a");
+    Table table = catalog.createTable(id, schema, spec);
+
+    List<Record> data = new ArrayList<>();
+    data.add(TestHelpers.createSimpleRecord(1L, "Michael"));
+    data.add(TestHelpers.createSimpleRecord(2L, "Andy"));
+    data.add(TestHelpers.createSimpleRecord(3L, "Berta"));
+
+    DataFile fileA = TestHelpers.writeFile(temp.newFile(), table, null, FileFormat.PARQUET, data);
+    DataFile fileB = TestHelpers.writeFile(temp.newFile(), table, null, FileFormat.PARQUET, data);
+    DataFile fileC = TestHelpers.writeFile(temp.newFile(), table, null, FileFormat.PARQUET, data);
+    table.newAppend().appendFile(fileA).commit();
+    table.newAppend().appendFile(fileB).commit();
+    table.newAppend().appendFile(fileC).commit();
+  }
+
+  @Test
+  public void testInputFormat () {
+    shell.execute("CREATE DATABASE source_db");
+
+    shell.execute(new StringBuilder()
+        .append("CREATE TABLE source_db.table_a ")
+        .append("STORED BY 'com.expediagroup.hiveberg.IcebergStorageHandler' ")
+        .append("LOCATION '")
+        .append(tableLocation.getAbsolutePath() + "/source_db/table_a")
+        .append("' TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog', 'iceberg.warehouse.location'='")
+        .append(tableLocation.getAbsolutePath())
+        .append("')")
+        .toString());
+
+    shell.execute(new StringBuilder()
+        .append("CREATE TABLE source_db.table_a_snapshots ")
+        .append("STORED BY 'com.expediagroup.hiveberg.IcebergStorageHandler' ")
+        .append("LOCATION '")
+        .append(tableLocation.getAbsolutePath() + "/source_db/table_a")
+        .append("' TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog','iceberg.snapshots.table'='true', " +
+            "'iceberg.table.name'='source_db.table_a', 'iceberg.warehouse.location'='")
+        .append(tableLocation.getAbsolutePath())
+        .append("')")
+        .toString());
+
+    List<Object[]> result = shell.executeStatement("SELECT * FROM source_db.table_a_snapshots");
+
+    assertEquals(3, result.size());
+  }
+}

--- a/src/test/java/com/expediagroup/hiveberg/TestReadSnapshotTable.java
+++ b/src/test/java/com/expediagroup/hiveberg/TestReadSnapshotTable.java
@@ -195,7 +195,7 @@ public class TestReadSnapshotTable {
         .append("STORED BY 'com.expediagroup.hiveberg.IcebergStorageHandler' ")
         .append("LOCATION '")
         .append(tableLocation.getAbsolutePath() + "/source_db/table_a")
-        .append("' TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog', 'hiveberg.snapshot.virtual.column.name' = 'metadata_snapshot_id', 'iceberg.warehouse.location'='")
+        .append("' TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog', 'iceberg.hive.snapshot.virtual.column.name' = 'metadata_snapshot_id', 'iceberg.warehouse.location'='")
         .append(tableLocation.getAbsolutePath())
         .append("')")
         .toString());

--- a/src/test/java/com/expediagroup/hiveberg/TestReadSnapshotTable.java
+++ b/src/test/java/com/expediagroup/hiveberg/TestReadSnapshotTable.java
@@ -22,7 +22,6 @@ import com.klarna.hiverunner.annotations.HiveSQL;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.DataFile;


### PR DESCRIPTION
This relates to issue #8 and #9
I've been testing out some possible ways of implementing the use of system tables via Hive, and this PR shows one way of extracting snapshot metadata from a regular Iceberg table into a separate Hive table you can query. Here's some more info on what's going on: 

**How you create the table**
1. First create your regular Hiveberg table and add some data to it
2. Now create a `snapshots` table that references your original table: 
```
CREATE TABLE source_db.table_a_snapshots
STORED BY 'com.expediagroup.hiveberg.IcebergStorageHandler'
LOCATION 'path_to_original_table'
TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog'
		'iceberg.snapshots.table'='true',
		'iceberg.table.name'='source_db.table_a', 
		'iceberg.warehouse.location'='path_to_original_table_warehouse')
```
The table should have a name like **[original_table_name]_snapshots** 

There are some extra TBLPROPERTIES needed for this table: 
1. `iceberg.table.name` is needed because we need a reference to the original table name so we can still load it properly **although** if we want to cut down on the amount of properties to set, we can probably extract the original table name in the InputFormat
1. `iceberg.snapshots.table` is set to true if you want to create a snapshots table

**How it works**
In `TableResolverUtil` which we use to load the Iceberg table via the catalog, it checks whether the snapshots flag^ is set to true, and if it is, it will load the [snapshot table](https://github.com/apache/incubator-iceberg/blob/master/core/src/main/java/org/apache/iceberg/SnapshotsTable.java) instead of the regular table. This is neat for a few reasons: 

- The IcebergSerDe uses the resolved table to fetch the schema of the table and creates the ObjectInspector based on the schema, so we don't need to pass in a separate SnapshotTable schema ourselves (i.e. no code changes needed in SerDe)
- We don't need to change much for the RecordReader, because the `SnapshotTable` still does a `TableScan` and creates `ScanTask`s that have `DataFiles` (what we use to read regular records)

The biggest change needed is for how we want to extract records out of the SnapshotTable `DataFile`, because it is slightly different. 
This new `DataFile` has a file format of `METADATA` (which means it points to the `metadata.json` file that we've explored before). Problems here: 
- There isn't currently a reader in Iceberg that reads this metadata file like the Parquet/ORC/Avro readers do, so I've implemented a work-around where we use the original `Table` object to fetch the list of snapshots and transfer the snapshot metadata into an Iceberg `Record` that Hive can read and output. 
- Adding this ^ meant the least change was needed to the actual `InputFormat` implementation

Running the test gives me this output: 
```
committed_at  | snapshot_id         | parent_id | operation | manifest_list        | summary 
----------------------------------------------------------------------------------------------
1588341995546   6023596325564622918   null        append     /var/folders/sg/...    {"added-data-files":"1","added-records":"3","changed-partition-count":"1","total-records":"3","total-data-files":"1"}
```

It's pretty cool that we can see some of this metadata from Hive, but some questions: 

**What next**
- Is this the best way of doing this?
- How can we then use this information to time travel in queries? I'm not sure if adding a column with snapshot_id's or something is useful (i.e. virtual columns) because every column currently would have the same snapshot_id because they're all part of the same snapshot...
- Should we get rid of `SnapshotIterable` and create a proper reader instead that reads from the `metadata.json` file? This means we don't have to pass the `Table` object around

**TODO's**
- Type conversion problems has meant I've put Iceberg Timestamps -> Hive Long type but maybe could do a conversion somehow to use Hive Timestamp type 
- Property fetching from conf can probably be cleaner
