### PR TITLE
Use HiveInputFormat to serialize filter expression

### DIFF
--- a/src/main/java/com/expediagroup/hiveberg/IcebergInputFormat.java
+++ b/src/main/java/com/expediagroup/hiveberg/IcebergInputFormat.java
@@ -66,7 +66,7 @@ public class IcebergInputFormat implements InputFormat,  CombineHiveInputFormat.
   static final String TABLE_FILTER_SERIALIZED = "hive.io.filter.expr.serialized";
   static final String TABLE_LOCATION = "location";
 
-  private Table table;
+  protected Table table;
 
   @Override
   public InputSplit[] getSplits(JobConf job, int numSplits) throws IOException {
@@ -95,7 +95,7 @@ public class IcebergInputFormat implements InputFormat,  CombineHiveInputFormat.
     return createSplits(tasks, location.toString());
   }
 
-  private InputSplit[] createSplits(List<CombinedScanTask> tasks, String name) {
+  protected InputSplit[] createSplits(List<CombinedScanTask> tasks, String name) {
     InputSplit[] splits = new InputSplit[tasks.size()];
     for (int i = 0; i < tasks.size(); i++) {
       splits[i] = new IcebergSplit(tasks.get(i), name);

--- a/src/main/java/com/expediagroup/hiveberg/IcebergInputFormat.java
+++ b/src/main/java/com/expediagroup/hiveberg/IcebergInputFormat.java
@@ -60,8 +60,11 @@ import static com.expediagroup.hiveberg.TableResolverUtil.resolveTableFromJob;
 public class IcebergInputFormat implements InputFormat,  CombineHiveInputFormat.AvoidSplitCombination {
   private static final Logger LOG = LoggerFactory.getLogger(IcebergInputFormat.class);
 
-  static final String TABLE_LOCATION = "location";
+  /**
+   * @see org.apache.hadoop.hive.ql.plan.TableScanDesc#FILTER_EXPR_CONF_STR
+   */
   static final String TABLE_FILTER_SERIALIZED = "hive.io.filter.expr.serialized";
+  static final String TABLE_LOCATION = "location";
 
   private Table table;
 

--- a/src/main/java/com/expediagroup/hiveberg/IcebergInputFormat.java
+++ b/src/main/java/com/expediagroup/hiveberg/IcebergInputFormat.java
@@ -63,7 +63,7 @@ public class IcebergInputFormat implements InputFormat,  CombineHiveInputFormat.
 
   static final String TABLE_LOCATION = "location";
 
-  protected Table table;
+  private Table table;
 
   @Override
   public InputSplit[] getSplits(JobConf job, int numSplits) throws IOException {
@@ -92,7 +92,7 @@ public class IcebergInputFormat implements InputFormat,  CombineHiveInputFormat.
     return createSplits(tasks, location.toString());
   }
 
-  protected InputSplit[] createSplits(List<CombinedScanTask> tasks, String name) {
+  private InputSplit[] createSplits(List<CombinedScanTask> tasks, String name) {
     InputSplit[] splits = new InputSplit[tasks.size()];
     for (int i = 0; i < tasks.size(); i++) {
       splits[i] = new IcebergSplit(tasks.get(i), name);

--- a/src/main/java/com/expediagroup/hiveberg/IcebergInputFormat.java
+++ b/src/main/java/com/expediagroup/hiveberg/IcebergInputFormat.java
@@ -61,7 +61,7 @@ public class IcebergInputFormat implements InputFormat,  CombineHiveInputFormat.
   private static final Logger LOG = LoggerFactory.getLogger(IcebergInputFormat.class);
 
   static final String TABLE_LOCATION = "location";
-  static final String TABLE_FILTER_SERIALIZED = "iceberg.filter.serialized";
+  static final String TABLE_FILTER_SERIALIZED = "hive.io.filter.expr.serialized";
 
   private Table table;
 

--- a/src/main/java/com/expediagroup/hiveberg/IcebergStorageHandler.java
+++ b/src/main/java/com/expediagroup/hiveberg/IcebergStorageHandler.java
@@ -17,7 +17,6 @@ package com.expediagroup.hiveberg;
 
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.ql.exec.SerializationUtilities;
 import org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat;
 import org.apache.hadoop.hive.ql.metadata.DefaultStorageHandler;
 import org.apache.hadoop.hive.ql.metadata.HiveStoragePredicateHandler;
@@ -84,20 +83,18 @@ public class IcebergStorageHandler extends DefaultStorageHandler implements Hive
   }
 
   /**
-   * Extract and serialize the filter expression and add it to the Configuration for the InputFormat to access.
    * @param jobConf Job configuration for InputFormat to access
    * @param deserializer Deserializer
    * @param exprNodeDesc Filter expression extracted by Hive
    * @return DecomposedPredicate that tells Hive what parts of the predicate are handled by the StorageHandler
-   * and what parts Hive needs to handle.
+   * and what parts Hive needs to handle. pushedPredicate gets serialized for access in the InputFormat.
    */
   @Override
   public DecomposedPredicate decomposePredicate(JobConf jobConf, Deserializer deserializer, ExprNodeDesc exprNodeDesc) {
-    getConf().set("iceberg.filter.serialized", SerializationUtilities.serializeObject(exprNodeDesc));
-
     //TODO: Decide what Iceberg can handle and what to return to Hive
     DecomposedPredicate predicate = new DecomposedPredicate();
     predicate.residualPredicate = (ExprNodeGenericFuncDesc) exprNodeDesc;
+    predicate.pushedPredicate = (ExprNodeGenericFuncDesc) exprNodeDesc;
     return predicate;
   }
 }

--- a/src/test/java/com/expediagroup/hiveberg/TestPredicatePushdown.java
+++ b/src/test/java/com/expediagroup/hiveberg/TestPredicatePushdown.java
@@ -1,0 +1,175 @@
+package com.expediagroup.hiveberg;
+
+import com.google.common.collect.Lists;
+import com.klarna.hiverunner.HiveShell;
+import com.klarna.hiverunner.StandaloneHiveRunner;
+import com.klarna.hiverunner.annotations.HiveSQL;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.ql.exec.SerializationUtilities;
+import org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat;
+import org.apache.hadoop.hive.ql.io.sarg.ConvertAstToSearchArg;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
+import org.apache.hadoop.hive.ql.metadata.DefaultStorageHandler;
+import org.apache.hadoop.hive.ql.metadata.HiveStoragePredicateHandler;
+import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
+import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
+import org.apache.hadoop.hive.serde2.AbstractSerDe;
+import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
+import org.apache.hadoop.hive.serde2.Deserializer;
+import org.apache.hadoop.mapred.InputFormat;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.OutputFormat;
+import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.apache.iceberg.types.Types;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+
+import static com.expediagroup.hiveberg.TableResolverUtil.pathAsURI;
+import static com.expediagroup.hiveberg.TableResolverUtil.resolveTableFromJob;
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(StandaloneHiveRunner.class)
+public class TestPredicatePushdown {
+
+  @HiveSQL(files = {}, autoStart = true)
+  private HiveShell shell;
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  private File tableLocation;
+  private Table table;
+
+  @Before
+  public void before() throws IOException {
+    tableLocation = temp.newFolder();
+    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
+        optional(2, "data", Types.StringType.get()));
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+
+    Configuration conf = new Configuration();
+    HadoopCatalog catalog = new HadoopCatalog(conf, tableLocation.getAbsolutePath());
+    TableIdentifier id = TableIdentifier.parse("source_db.table_a");
+    table = catalog.createTable(id, schema, spec);
+  }
+
+  /**
+   * This test is to recreate an old bug found in the StorageHandler where the filter property wasn't
+   * getting reset between queries.
+   */
+  @Test
+  public void oldVersionOfStorageHandler() throws IOException {
+    List<Record> dataA = new ArrayList<>();
+    dataA.add(TestHelpers.createSimpleRecord(1L, "Michael"));
+
+    List<Record> dataB = new ArrayList<>();
+    dataB.add(TestHelpers.createSimpleRecord(2L, "Andy"));
+
+    List<Record> dataC = new ArrayList<>();
+    dataC.add(TestHelpers.createSimpleRecord(3L, "Berta"));
+
+    DataFile fileA = TestHelpers.writeFile(temp.newFile(), table, null, FileFormat.PARQUET, dataA);
+    DataFile fileB = TestHelpers.writeFile(temp.newFile(), table, null, FileFormat.PARQUET, dataB);
+    DataFile fileC = TestHelpers.writeFile(temp.newFile(), table, null, FileFormat.PARQUET, dataC);
+
+    table.newAppend().appendFile(fileA).commit();
+    table.newAppend().appendFile(fileB).commit();
+    table.newAppend().appendFile(fileC).commit();
+
+    shell.execute("CREATE DATABASE source_db");
+    shell.execute(new StringBuilder()
+        .append("CREATE TABLE source_db.table_a ")
+        .append("STORED BY 'com.expediagroup.hiveberg.TestPredicatePushdown$OldIcebergStorageHandler' ")
+        .append("LOCATION '")
+        .append(tableLocation.getAbsolutePath() + "/source_db/table_a")
+        .append("' TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog', 'iceberg.warehouse.location'='")
+        .append(tableLocation.getAbsolutePath())
+        .append("')")
+        .toString());
+
+    List<Object[]> resultFullTable = shell.executeStatement("SELECT * FROM source_db.table_a");
+    assertEquals(3, resultFullTable.size());
+
+    List<Object[]> resultFilterId = shell.executeStatement("SELECT * FROM source_db.table_a WHERE id = 1");
+    assertEquals(1, resultFilterId.size());
+
+    List<Object[]> resultFullTableAfterQuery = shell.executeStatement("SELECT * FROM source_db.table_a");
+    //Will only return 1 row because filter from last query is still set in Conf
+    assertEquals(1, resultFullTableAfterQuery.size());
+  }
+
+  private static class OldIcebergStorageHandler extends DefaultStorageHandler implements HiveStoragePredicateHandler {
+
+    private Configuration conf;
+
+    @Override
+    public Class<? extends InputFormat> getInputFormatClass() {
+      return OldIcebergInputFormat.class;
+    }
+
+    @Override
+    public Class<? extends AbstractSerDe> getSerDeClass() {
+      return IcebergSerDe.class;
+    }
+
+    @Override
+    public DecomposedPredicate decomposePredicate(JobConf jobConf, Deserializer deserializer, ExprNodeDesc exprNodeDesc) {
+      getConf().set("iceberg.filter.serialized", SerializationUtilities.serializeObject(exprNodeDesc));
+
+      DecomposedPredicate predicate = new DecomposedPredicate();
+      predicate.residualPredicate = (ExprNodeGenericFuncDesc) exprNodeDesc;
+      return predicate;
+    }
+  }
+
+  private static class OldIcebergInputFormat extends IcebergInputFormat {
+
+    @Override
+    public InputSplit[] getSplits(JobConf job, int numSplits) throws IOException {
+      String TABLE_FILTER_SERIALIZED = "iceberg.filter.serialized";
+      table = resolveTableFromJob(job);
+      URI location = pathAsURI(job.get(TABLE_LOCATION));
+
+      String[] readColumns = ColumnProjectionUtils.getReadColumnNames(job);
+      List<CombinedScanTask> tasks;
+      if(job.get(TABLE_FILTER_SERIALIZED) == null) {
+        tasks = Lists.newArrayList(table
+            .newScan()
+            .select(readColumns)
+            .planTasks());
+      } else {
+        ExprNodeGenericFuncDesc exprNodeDesc = SerializationUtilities.
+            deserializeObject(job.get(TABLE_FILTER_SERIALIZED), ExprNodeGenericFuncDesc.class);
+        SearchArgument sarg = ConvertAstToSearchArg.create(job, exprNodeDesc);
+        Expression filter = IcebergFilterFactory.generateFilterExpression(sarg);
+
+        tasks = Lists.newArrayList(table
+            .newScan()
+            .select(readColumns)
+            .filter(filter)
+            .planTasks());
+      }
+      return createSplits(tasks, location.toString());
+    }
+  }
+}


### PR DESCRIPTION
I discovered a small bug whilst running time-travel queries:
- The old way I was setting the serialized filter in the `Configuration` was not getting reset each time a new query was run, meaning if I ran a query with a filter and then a query without a filter, the second query would still have the filter applied

This is a small change that delegates serializing the filter expression to `HiveInputFormat` instead of setting the property ourselves in the StorageHandler as we currently do. I tried to use this originally but couldn't get it to work, but have since discovered that to get Hive to set the filter property I need to return the expression to be serialized as the `pushedPredicate` part of the `DecomposedPredicate` and it's all nicely handled for me 😍

https://github.com/apache/hive/blob/master/ql/src/java/org/apache/hadoop/hive/ql/io/HiveInputFormat.java#L879

This isn't a huge change and I've run the tests to check it works with using this new property instead.
