### PR TITLE
Remove use of iceberg.warehouse.location property

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,17 @@ For example, if you created the Hive table as shown above then your Iceberg tabl
 TableIdentifier id = TableIdentifier.parse("source_db.table_a");
 ```
 
-#### Setting TBLPROPERTIES correctly
-You need to set the `TBLPROPERTIES` differently depending on how you've created your Iceberg table.
-- If you used **HadoopTables** to create your Iceberg table, add one extra configuration: 
-```sql 
-    TBLPROPERTIES('iceberg.catalog' = 'hadoop.tables')
+#### Setting TBLPROPERTIES
+You need to set one additional table property when using Hiveberg: 
+- If you used **HadoopTables** to create your original Iceberg table, set this property:
+``` 
+TBLPROPERTIES('iceberg.catalog'='hadoop.tables')
 ```
-- If you used **HadoopCatalog** to create your Iceberg table, add these extra configurations: 
-```sql 
-    TBLPROPERTIES('iceberg.catalog' = 'hadoop.catalog', 'iceberg.warehouse.location' = 'path_to_warehouse_location')
+
+- If you used **HadoopCatalog** to create your original Iceberg table, set this property:
+``` 
+TBLPROPERTIES('iceberg.catalog'='hadoop.catalog')
 ```
-These properties need to be set so the `InputFormat` can load the Iceberg table using the correct class.
 
 ### IcebergStorageHandler
 This is implemented as a simplified option for creating Hiveberg tables. The Hive DDL should instead look like:
@@ -69,7 +69,7 @@ You can view snapshot metadata from your table by creating a `__snapshots` syste
 CREATE TABLE source_db.table_a__snapshots
   STORED BY 'com.expediagroup.hiveberg.IcebergStorageHandler'
   LOCATION 'path_to_original_data_table'
-    TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog', 'iceberg.warehouse.location'='path_to_original_table_warehouse')
+    TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog')
 ```
 #### Notes
 - It is important that the table name ends with `__snapshots` as the `InputFormat` uses this to determine when to load the snapshot metadata table instead of the regular data table. 

--- a/src/main/java/com/expediagroup/hiveberg/TableResolverUtil.java
+++ b/src/main/java/com/expediagroup/hiveberg/TableResolverUtil.java
@@ -27,12 +27,16 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.hadoop.HadoopCatalog;
 import org.apache.iceberg.hadoop.HadoopTables;
 
+import static java.lang.Boolean.TRUE;
+import static java.lang.Boolean.parseBoolean;
+
 final class TableResolverUtil {
 
   static final String CATALOG_NAME = "iceberg.catalog";
   static final String HADOOP_CATALOG = "hadoop.catalog";
   static final String HADOOP_TABLES = "hadoop.tables";
   static final String HIVE_CATALOG = "hive.catalog";
+  static final String ICEBERG_SNAPSHOTS_TABLE_SUFFIX = ".snapshots";
   static final String SNAPSHOT_TABLE = "iceberg.snapshots.table";
   static final String SNAPSHOT_TABLE_SUFFIX = "__snapshots";
   static final String TABLE_LOCATION = "location";
@@ -66,7 +70,7 @@ final class TableResolverUtil {
         String tableName = properties.getProperty(TABLE_NAME);
         TableIdentifier id = TableIdentifier.parse(tableName);
         if(tableName.endsWith(SNAPSHOT_TABLE_SUFFIX)) {
-          if(properties.getProperty(SNAPSHOT_TABLE, "true").equalsIgnoreCase("false")) {
+          if(!parseBoolean(properties.getProperty(SNAPSHOT_TABLE, TRUE.toString()))) {
             String tablePath = id.toString().replaceAll("\\.","/");
             URI warehouseLocation = pathAsURI(tableLocation.getPath().replaceAll(tablePath, ""));
             HadoopCatalog catalog = new HadoopCatalog(conf, warehouseLocation.getPath());
@@ -91,7 +95,7 @@ final class TableResolverUtil {
     HadoopCatalog catalog = new HadoopCatalog(conf, warehouseLocation.getPath());
     String baseTableName = StringUtils.removeEnd(tableName, SNAPSHOT_TABLE_SUFFIX);
 
-    TableIdentifier snapshotsId = TableIdentifier.parse(baseTableName + ".snapshots");
+    TableIdentifier snapshotsId = TableIdentifier.parse(baseTableName + ICEBERG_SNAPSHOTS_TABLE_SUFFIX);
     return catalog.loadTable(snapshotsId);
   }
 

--- a/src/test/java/com/expediagroup/hiveberg/TestInputFormatWithHadoopCatalog.java
+++ b/src/test/java/com/expediagroup/hiveberg/TestInputFormatWithHadoopCatalog.java
@@ -166,14 +166,6 @@ public class TestInputFormatWithHadoopCatalog {
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testGetSplitsNoWarehouseLocation() throws IOException {
-    conf.set("iceberg.catalog", "hadoop.catalog");
-    conf.set("location", "file:" + tableLocation);
-    conf.set("name", "source_db.table_a");
-    format.getSplits(conf, 1);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
   public void testGetSplitsNoLocation() throws IOException {
     conf.set("iceberg.catalog", "hadoop.catalog");
     conf.set("iceberg.warehouse.location", "file:" + tableLocation);
@@ -184,15 +176,6 @@ public class TestInputFormatWithHadoopCatalog {
   @Test(expected = IllegalArgumentException.class)
   public void testGetSplitsNoCatalog() throws IOException {
     conf.set("iceberg.warehouse.location", "file:" + tableLocation);
-    conf.set("location", "file:" + tableLocation);
-    conf.set("name", "source_db.table_a");
-    format.getSplits(conf, 1);
-  }
-
-  @Test(expected = IOException.class)
-  public void testGetSplitsInvalidWarehouseLocationUri() throws IOException {
-    conf.set("iceberg.warehouse.location", "http:");
-    conf.set("iceberg.catalog", "hadoop.catalog");
     conf.set("location", "file:" + tableLocation);
     conf.set("name", "source_db.table_a");
     format.getSplits(conf, 1);

--- a/src/test/java/com/expediagroup/hiveberg/TestJoinTablesWithHadoopCatalog.java
+++ b/src/test/java/com/expediagroup/hiveberg/TestJoinTablesWithHadoopCatalog.java
@@ -104,9 +104,7 @@ public class TestJoinTablesWithHadoopCatalog {
         .append("OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat' ")
         .append("LOCATION '")
         .append(tableLocation.getAbsolutePath() + "/source_db/table_a")
-        .append("' TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog', 'iceberg.warehouse.location'='")
-        .append(tableLocation.getAbsolutePath())
-        .append("')")
+        .append("' TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog')")
         .toString());
 
     shell.execute(new StringBuilder()
@@ -117,9 +115,7 @@ public class TestJoinTablesWithHadoopCatalog {
         .append("OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat' ")
         .append("LOCATION '")
         .append(tableLocation.getAbsolutePath() + "/source_db/table_b")
-        .append("' TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog', 'iceberg.warehouse.location'='")
-        .append(tableLocation.getAbsolutePath())
-        .append("')")
+        .append("' TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog')")
         .toString());
 
     List<Object[]> result = shell.executeStatement("SELECT table_a.first_name, table_b.name, table_b.salary " +
@@ -137,9 +133,7 @@ public class TestJoinTablesWithHadoopCatalog {
         .append("STORED BY 'com.expediagroup.hiveberg.IcebergStorageHandler' ")
         .append("LOCATION '")
         .append(tableLocation.getAbsolutePath() + "/source_db/table_a")
-        .append("' TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog', 'iceberg.warehouse.location'='")
-        .append(tableLocation.getAbsolutePath())
-        .append("')")
+        .append("' TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog')")
         .toString());
 
     shell.execute(new StringBuilder()
@@ -147,9 +141,7 @@ public class TestJoinTablesWithHadoopCatalog {
         .append("STORED BY 'com.expediagroup.hiveberg.IcebergStorageHandler' ")
         .append("LOCATION '")
         .append(tableLocation.getAbsolutePath() + "/source_db/table_b")
-        .append("' TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog', 'iceberg.warehouse.location'='")
-        .append(tableLocation.getAbsolutePath())
-        .append("')")
+        .append("' TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog')")
         .toString());
 
     List<Object[]> result = shell.executeStatement("SELECT table_a.first_name, table_b.name, table_b.salary " +

--- a/src/test/java/com/expediagroup/hiveberg/TestReadSnapshotTable.java
+++ b/src/test/java/com/expediagroup/hiveberg/TestReadSnapshotTable.java
@@ -94,9 +94,7 @@ public class TestReadSnapshotTable {
         .append("STORED BY 'com.expediagroup.hiveberg.IcebergStorageHandler' ")
         .append("LOCATION '")
         .append(tableLocation.getAbsolutePath() + "/source_db/table_a")
-        .append("' TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog', 'iceberg.warehouse.location'='")
-        .append(tableLocation.getAbsolutePath())
-        .append("')")
+        .append("' TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog')")
         .toString());
 
     shell.execute(new StringBuilder()
@@ -104,9 +102,7 @@ public class TestReadSnapshotTable {
         .append("STORED BY 'com.expediagroup.hiveberg.IcebergStorageHandler' ")
         .append("LOCATION '")
         .append(tableLocation.getAbsolutePath() + "/source_db/table_a")
-        .append("' TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog', 'iceberg.warehouse.location'='")
-        .append(tableLocation.getAbsolutePath())
-        .append("')")
+        .append("' TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog')")
         .toString());
 
     List<Object[]> result = shell.executeStatement("SELECT * FROM source_db.table_a__snapshots");
@@ -131,9 +127,7 @@ public class TestReadSnapshotTable {
         .append("STORED BY 'com.expediagroup.hiveberg.IcebergStorageHandler' ")
         .append("LOCATION '")
         .append(tableLocation.getAbsolutePath() + "/source_db/table_a__snapshots")
-        .append("' TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog','iceberg.snapshots.table'='false', 'iceberg.warehouse.location'='")
-        .append(tableLocation.getAbsolutePath())
-        .append("')")
+        .append("' TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog','iceberg.snapshots.table'='false')")
         .toString());
 
     List<Object[]> result = shell.executeStatement("SELECT * FROM source_db.table_a__snapshots");
@@ -150,9 +144,7 @@ public class TestReadSnapshotTable {
         .append("STORED BY 'com.expediagroup.hiveberg.IcebergStorageHandler' ")
         .append("LOCATION '")
         .append(tableLocation.getAbsolutePath() + "/source_db/table_a")
-        .append("' TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog', 'iceberg.warehouse.location'='")
-        .append(tableLocation.getAbsolutePath())
-        .append("')")
+        .append("' TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog')")
         .toString());
 
     shell.execute(new StringBuilder()
@@ -160,9 +152,7 @@ public class TestReadSnapshotTable {
         .append("STORED BY 'com.expediagroup.hiveberg.IcebergStorageHandler' ")
         .append("LOCATION '")
         .append(tableLocation.getAbsolutePath() + "/source_db/table_a")
-        .append("' TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog', 'iceberg.warehouse.location'='")
-        .append(tableLocation.getAbsolutePath())
-        .append("')")
+        .append("' TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog')")
         .toString());
 
     List<Object[]> resultLatestTable = shell.executeStatement("SELECT * FROM source_db.table_a");
@@ -194,10 +184,8 @@ public class TestReadSnapshotTable {
         .append("CREATE TABLE source_db.table_b ")
         .append("STORED BY 'com.expediagroup.hiveberg.IcebergStorageHandler' ")
         .append("LOCATION '")
-        .append(tableLocation.getAbsolutePath() + "/source_db/table_a")
-        .append("' TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog', 'iceberg.hive.snapshot.virtual.column.name' = 'metadata_snapshot_id', 'iceberg.warehouse.location'='")
-        .append(tableLocation.getAbsolutePath())
-        .append("')")
+        .append(tableLocation.getAbsolutePath() + "/source_db/table_b")
+        .append("' TBLPROPERTIES ('iceberg.catalog'='hadoop.catalog', 'iceberg.hive.snapshot.virtual.column.name' = 'metadata_snapshot_id')")
         .toString());
 
     List<Object[]> resultLatestTable = shell.executeStatement("SELECT * FROM source_db.table_b");

--- a/src/test/java/com/expediagroup/hiveberg/TestTableResolverUtil.java
+++ b/src/test/java/com/expediagroup/hiveberg/TestTableResolverUtil.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2020 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.hiveberg;
+
+
+import org.apache.hadoop.mapred.JobConf;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestTableResolverUtil {
+
+  @Test
+  public void extractWarehouseLocationRegularTable() {
+    // This is the style of input expected from HiveConf
+    String testLocation = "some/folder/database/table_a";
+    String testTableName = "database.table_a";
+
+    String expected = "some/folder/";
+    String result = TableResolverUtil.extractWarehousePath(testLocation, testTableName);
+
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void extractPropertyFromJobConf() {
+    JobConf conf = new JobConf();
+    String key = "iceberg.catalog";
+    String value = "hadoop.tables";
+
+    conf.set(key, value);
+
+    String result = TableResolverUtil.extractProperty(conf, key);
+
+    assertEquals(value, result);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void extractNonExistentProperty() {
+    JobConf conf = new JobConf();
+    String key = "iceberg.catalog";
+
+    TableResolverUtil.extractProperty(conf, key);
+  }
+
+}


### PR DESCRIPTION
Fixes #19 :))
This PR is to remove the `iceberg.warehouse.location` configuration property that users currently need to set if they're referencing a `HadoopCatalog` table by inferring the warehouse location from the table path - the table identifier.

I added some specific tests for individual methods in TableResolverUtil but also made sure all regular HiveRunner tests passed with change in table configuration