### PR TITLE
Fix null values in snapshot__id columns

### DIFF
--- a/src/main/java/com/expediagroup/hiveberg/IcebergInputFormat.java
+++ b/src/main/java/com/expediagroup/hiveberg/IcebergInputFormat.java
@@ -163,19 +163,14 @@ public class IcebergInputFormat implements InputFormat,  CombineHiveInputFormat.
     public boolean next(Void key, IcebergWritable value) {
       if (recordIterator.hasNext()) {
         currentRecord = recordIterator.next();
-        if (table instanceof SnapshotsTable) {
-          value.setRecord(currentRecord);
-        } else {
-          value.setRecord(recordWithVirtualColumn(currentRecord, currentSnapshotId, table.schema(), virtualSnapshotIdColumnName));
-          LOG.debug("Set virtual column id to: " + currentSnapshotId);
-        }
+        value.setRecord(resolveRecord());
         return true;
       }
 
       if(tasks.hasNext()){
         nextTask();
         currentRecord = recordIterator.next();
-        value.setRecord(currentRecord);
+        value.setRecord(resolveRecord());
         return true;
       }
       return false;
@@ -211,6 +206,14 @@ public class IcebergInputFormat implements InputFormat,  CombineHiveInputFormat.
     @Override
     public float getProgress() throws IOException {
       return 0;
+    }
+
+    private Record resolveRecord() {
+      if (table instanceof SnapshotsTable) {
+        return currentRecord;
+      } else {
+        return recordWithVirtualColumn(currentRecord, currentSnapshotId, table.schema(), virtualSnapshotIdColumnName);
+      }
     }
   }
 

--- a/src/main/java/com/expediagroup/hiveberg/IcebergInputFormat.java
+++ b/src/main/java/com/expediagroup/hiveberg/IcebergInputFormat.java
@@ -163,14 +163,14 @@ public class IcebergInputFormat implements InputFormat,  CombineHiveInputFormat.
     public boolean next(Void key, IcebergWritable value) {
       if (recordIterator.hasNext()) {
         currentRecord = recordIterator.next();
-        value.setRecord(resolveRecord());
+        value.setRecord(resolveAppropriateRecordForTableType());
         return true;
       }
 
       if(tasks.hasNext()){
         nextTask();
         currentRecord = recordIterator.next();
-        value.setRecord(resolveRecord());
+        value.setRecord(resolveAppropriateRecordForTableType());
         return true;
       }
       return false;
@@ -208,7 +208,7 @@ public class IcebergInputFormat implements InputFormat,  CombineHiveInputFormat.
       return 0;
     }
 
-    private Record resolveRecord() {
+    private Record resolveAppropriateRecordForTableType() {
       if (table instanceof SnapshotsTable) {
         return currentRecord;
       } else {

--- a/src/test/java/com/expediagroup/hiveberg/TestInputFormatWithMultipleTasks.java
+++ b/src/test/java/com/expediagroup/hiveberg/TestInputFormatWithMultipleTasks.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (C) 2020 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.hiveberg;
+
+import com.google.common.collect.Lists;
+import com.klarna.hiverunner.HiveShell;
+import com.klarna.hiverunner.StandaloneHiveRunner;
+import com.klarna.hiverunner.annotations.HiveSQL;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordReader;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.types.Types;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(StandaloneHiveRunner.class)
+public class TestInputFormatWithMultipleTasks {
+
+  @HiveSQL(files = {}, autoStart = true)
+  private HiveShell shell;
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  private File tableLocation;
+  private IcebergInputFormat format = new IcebergInputFormat();
+  private JobConf conf = new JobConf();
+  private long snapshotId;
+
+  @Before
+  public void before() throws IOException {
+    tableLocation = temp.newFolder();
+    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
+        optional(2, "data", Types.StringType.get()));
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+
+    HadoopTables tables = new HadoopTables();
+    Table table = tables.create(schema, spec, tableLocation.getAbsolutePath());
+
+    List<Record> data = new ArrayList<>();
+    data.add(TestHelpers.createSimpleRecord(1L, "Michael"));
+    data.add(TestHelpers.createSimpleRecord(2L, "Andy"));
+
+    DataFile fileA = TestHelpers.writeFile(temp.newFile(), table, null, FileFormat.PARQUET, data);
+    table.newAppend().appendFile(fileA).commit();
+
+    DataFile fileB = TestHelpers.writeFile(temp.newFile(), table, null, FileFormat.PARQUET, data);
+    table.newAppend().appendFile(fileB).commit();
+
+    snapshotId = table.currentSnapshot().snapshotId();
+  }
+
+  @Test
+  public void testAllRowsIncludeSnapshotId () {
+    shell.execute("CREATE DATABASE source_db");
+    shell.execute(new StringBuilder()
+        .append("CREATE TABLE source_db.table_a ")
+        .append("ROW FORMAT SERDE 'com.expediagroup.hiveberg.IcebergSerDe' ")
+        .append("STORED AS ")
+        .append("INPUTFORMAT 'com.expediagroup.hiveberg.IcebergInputFormat' ")
+        .append("OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat' ")
+        .append("LOCATION '")
+        .append(tableLocation.getAbsolutePath())
+        .append("' TBLPROPERTIES ('iceberg.catalog'='hadoop.tables'")
+        .append(")")
+        .toString());
+
+    List<Object[]> result = shell.executeStatement("SELECT * FROM source_db.table_a");
+
+    assertEquals(4, result.size());
+    assertEquals(snapshotId, result.get(0)[2]);
+    assertEquals(snapshotId, result.get(1)[2]);
+    assertEquals(snapshotId, result.get(2)[2]);
+    assertEquals(snapshotId, result.get(3)[2]);
+  }
+
+}


### PR DESCRIPTION
When I was testing Hiveberg on EMR I noticed for some queries I was getting results like this: 
![image](https://user-images.githubusercontent.com/32553472/83733901-252f4d80-a646-11ea-9258-6b866804bfbc.png)

This happens because within the `next()` method of RecordReader, theres a point when we switch FileScanTask's if there are no more rows to read from the current File, and for the row read in this case, we previously didn't append the snapshot ID metadata to the row (something I completely missed earlier, so I'm glad it surfaced in this round of testing)

In the unit tests I hadn't noticed that some random rows were missing snapshot__id values partly because most tests only used one DataFile so we didn't hit the code path in RecordReader where we had to switch ScanTasks. This fix makes sure we also add snapshot__id values to rows when we switch ScanTask's and adds a test that checks for this too.