### PR TITLE
Add time-travel option to HadoopTables catalog

### DIFF
--- a/src/test/java/com/expediagroup/hiveberg/TestReadSnapshotTableWithHadoopCatalog.java
+++ b/src/test/java/com/expediagroup/hiveberg/TestReadSnapshotTableWithHadoopCatalog.java
@@ -45,7 +45,7 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(StandaloneHiveRunner.class)
-public class TestReadSnapshotTable {
+public class TestReadSnapshotTableWithHadoopCatalog {
 
   @HiveSQL(files = {}, autoStart = true)
   private HiveShell shell;


### PR DESCRIPTION
When first testing time travel and system tables I focused on getting it working for the `HadoopCatalog` option but I've since been testing and found how to implement it for `HadoopTables` as well. 